### PR TITLE
Reduce fetch calls

### DIFF
--- a/Client/problema.js
+++ b/Client/problema.js
@@ -1,5 +1,5 @@
 import { ObtenerBloque, ObtenerProblemasDeBloque } from '/tabla.js'
-import { Simplificar } from '/formateo.js'
+import { Simplificar, SimplificarMultiples } from '/formateo.js'
 
 let contenedorProblemas = document.getElementById('contenedorProblemas');
 
@@ -239,9 +239,7 @@ async function GenerarValoresDeProblema(problema)
         }
     }
 
-    problema.Respuesta = await Simplificar(problema.Respuesta);
-    for (let k = 0; k < problema.FormulaValoresExplicacion.length; k++)
-    {
-        problema.ValoresExplicacion[k] = await Simplificar(problema.ValoresExplicacion[k]);
-    }
+    let formulasSimplificadas = await SimplificarMultiples([ problema.Respuesta ].concat(problema.ValoresExplicacion));
+    problema.Respuesta = formulasSimplificadas[0];
+    problema.ValoresExplicacion = formulasSimplificadas.slice(1);
 }

--- a/Server/formateo.js
+++ b/Server/formateo.js
@@ -4,3 +4,14 @@ export async function Simplificar(formula)
     let resultado = await fetch('/Evaluate/' + formulaFormateada).then(res => res.json()).then(json => json.resultado);
     return resultado;
 }
+
+export async function SimplificarMultiples(formulas)
+{
+    let formulasFormateadas = '';
+    for (let i = 0; i < formulas.length; i++)
+    {
+        formulasFormateadas += encodeURIComponent(formulas[i]) + (i < formulas.length - 1 ? '|' : '');
+    }
+    let resultados = await fetch('/EvaluateMany/' + formulasFormateadas).then(res => res.json()).then(json => json.resultado);
+    return resultados;
+}

--- a/Server/index.js
+++ b/Server/index.js
@@ -44,6 +44,22 @@ app.get('/Evaluate/:formula', (req, res) => {
     res.send({ "resultado": resultado.toString() });
 })
 
+app.get('/EvaluateMany/:formulas', (req, res) => {
+    const { formulas } = req.params;
+
+    let individualFormulas = formulas.split('|');
+    for (let i = 0; i < individualFormulas.length; i++)
+    {
+        try {
+            individualFormulas[i] = simplify(individualFormulas[i]).toString();
+        } catch(error) {
+            throw new Error('Element with index: ' + i.toString() + ', with value: ' + individualFormulas[i] + ' could not be simplified');
+        }
+    }
+
+    res.send({ "resultado": individualFormulas });
+})
+
 // Formateo //
 
 app.get('/tabla.js', (req, res) => {


### PR DESCRIPTION
Generating random problem values took many fetch calls because of the simplification function. Now it's done in a single call to improve performance.